### PR TITLE
UserPanel: is rendered when headers are not sent or session is active

### DIFF
--- a/src/Bridges/SecurityTracy/UserPanel.php
+++ b/src/Bridges/SecurityTracy/UserPanel.php
@@ -34,7 +34,7 @@ class UserPanel extends Nette\Object implements Tracy\IBarPanel
 	 */
 	public function getTab()
 	{
-		if (headers_sent()) {
+		if (headers_sent() && !session_id()) {
 			return;
 		}
 


### PR DESCRIPTION
I think UserPanel can be rendered when session is active.
