### PR TITLE
replacement md5 using crypt function in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ class MyAuthenticator extends Nette\Object implements NS\IAuthenticator
 			throw new NS\AuthenticationException('User not found.');
 		}
 
-		if (NS\Passwords::verify($password, $row->password)) {
+		if (!NS\Passwords::verify($password, $row->password)) {
 			throw new NS\AuthenticationException('Invalid password.');
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ class MyAuthenticator extends Nette\Object implements NS\IAuthenticator
 			throw new NS\AuthenticationException('User not found.');
 		}
 
-		if ($row->password !== md5($password)) {
+		if ($row->password !== crypt($password, $row->password)) {
 			throw new NS\AuthenticationException('Invalid password.');
 		}
 
@@ -129,7 +129,7 @@ class MyAuthenticator extends Nette\Object implements NS\IAuthenticator
 }
 ```
 
-Class `MyAuthenticator` communicates with the database using [Nette\Database |database] layer and works with table `users`,  where it grabs `username` and md5 hash of `password` in the appropriate columns. If the password check is successful, it returns new identity with user ID and role, which we will mention [later | #roles];
+Class `MyAuthenticator` communicates with the database using [Nette\Database |database] layer and works with table `users`,  where it grabs `username` and hash of `password` in the appropriate columns. If the password check is successful, it returns new identity with user ID and role, which we will mention [later | #roles];
 
 This authenticator would be configured in the `config.neon` file like this:
 

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ class MyAuthenticator extends Nette\Object implements NS\IAuthenticator
 			throw new NS\AuthenticationException('User not found.');
 		}
 
-		if ($row->password !== crypt($password, $row->password)) {
+		if (NS\Passwords::verify($password, $row->password)) {
 			throw new NS\AuthenticationException('Invalid password.');
 		}
 


### PR DESCRIPTION
MD5 hash is ugly, crypt too, but less. I would like to use bcrypt, but the example must be simple and compatible with PHP 5.3.1.