### PR TITLE
Identity: add property annotation

### DIFF
--- a/src/Security/Identity.php
+++ b/src/Security/Identity.php
@@ -15,6 +15,7 @@ use Nette;
  *
  * @property   mixed $id
  * @property   array $roles
+ * @property   array $data
  */
 class Identity implements IIdentity
 {

--- a/tests/Security/Identity.phpt
+++ b/tests/Security/Identity.phpt
@@ -19,6 +19,7 @@ test(function () {
 	Assert::same(['admin'], $id->getRoles());
 	Assert::same(['admin'], $id->roles);
 	Assert::same(['name' => 'John'], $id->getData());
+	Assert::same(['name' => 'John'], $id->data);
 	Assert::same('John', $id->name);
 });
 


### PR DESCRIPTION
It allows access data array directly using `$id->data['name']` instead of `$id->getData()['name']` (Nette 2.4 compatibility fix).