### PR TITLE
comment fix & clarification

### DIFF
--- a/src/Bridges/SecurityDI/SecurityExtension.php
+++ b/src/Bridges/SecurityDI/SecurityExtension.php
@@ -20,8 +20,8 @@ class SecurityExtension extends Nette\DI\CompilerExtension
 	public $defaults = [
 		'debugger' => TRUE,
 		'users' => [], // of [user => password] or [user => ['password' => password, 'roles' => [role]]]
-		'roles' => [], // of [role => parents]
-		'resources' => [], // of [resource => parents]
+		'roles' => [], // of [role => parent(s)]
+		'resources' => [], // of [resource => parent]
 	];
 
 	/** @var bool */


### PR DESCRIPTION
- bug fix? **no**
- new feature? **no**
- BC break? **no**
- doc PR: **no** need

*Line 24*: A fix of comment for `$defaults['resources']` - a resource can only have a single parent, `addResource` throws an exception otherwise.

Furthermore, the implementation of `addRole` allows the user to present either an array of parents or a single parent. Thus the change to the comment on *line 23* for clarification.
