### PR TITLE
Using named parameters instead of $credentials

### DIFF
--- a/src/Security/IAuthenticator.php
+++ b/src/Security/IAuthenticator.php
@@ -13,24 +13,21 @@ namespace Nette\Security;
 /**
  * Performs authentication.
  */
-interface IAuthenticator
-{
-	/** Credential key */
-	public const
-		USERNAME = 0,
-		PASSWORD = 1;
+interface IAuthenticator {
 
-	/** Exception error code */
-	public const
-		IDENTITY_NOT_FOUND = 1,
-		INVALID_CREDENTIAL = 2,
-		FAILURE = 3,
-		NOT_APPROVED = 4;
+    /** Exception error code */
+    public const
+        IDENTITY_NOT_FOUND = 1,
+        INVALID_CREDENTIAL = 2,
+        FAILURE = 3,
+        NOT_APPROVED = 4;
 
-	/**
-	 * Performs an authentication against e.g. database.
-	 * and returns IIdentity on success or throws AuthenticationException
-	 * @throws AuthenticationException
-	 */
-	function authenticate(array $credentials): IIdentity;
+    /**
+     * Performs an authentication against e.g. database.
+     * and returns IIdentity on success or throws AuthenticationException
+     * @param string $identification
+     * @param null|string $password
+     * @return IIdentity
+     */
+    function authenticate(string $identification, ?string $password): IIdentity;
 }

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -80,7 +80,8 @@ class User
 	{
 		$this->logout(true);
 		if (!$user instanceof IIdentity) {
-			$user = $this->getAuthenticator()->authenticate(func_get_args());
+		    //TODO check $user type
+			$user = $this->getAuthenticator()->authenticate($user, $password);
 		}
 		$this->storage->setIdentity($user);
 		$this->storage->setAuthenticated(true);


### PR DESCRIPTION
Why wasn't this done in the first place?

- bug fix? no   
- new feature? no
- BC break? yes

I honestly don't fully understand the decision-making during this, I don't think this method is being used anywhere else.