### PR TITLE
Permission deny with role that has everything allowed

### DIFF
--- a/tests/Security/Permission.PrivilegeDeny.phpt
+++ b/tests/Security/Permission.PrivilegeDeny.phpt
@@ -14,6 +14,9 @@ require __DIR__ . '/../bootstrap.php';
 
 
 $acl = new Permission;
+$acl->addRole('admin');
+$acl->allow('admin');
 $acl->allow();
 $acl->deny(null, null, 'somePrivilege');
 Assert::false($acl->isAllowed(null, null, 'somePrivilege'));
+Assert::false($acl->isAllowed('admin', null, 'somePrivilege'));


### PR DESCRIPTION
- bug fix? yes/no
- new feature? yes/no
- BC break? yes

Hi,
is this bug or feature?

Use case:
I have user role `admin` which has everything enabled by default. But in some circumstances I want to deny specific privilege on specific resource to ALL user roles, including that `admin`.

I know I should create issue, but this is more narrow way how to show something :-)