### PR TITLE
Passwords: hash(): Password can not be empty.

### DIFF
--- a/src/Security/Passwords.php
+++ b/src/Security/Passwords.php
@@ -41,6 +41,10 @@ class Passwords
 	 */
 	public function hash(string $password): string
 	{
+		if ($password === '') {
+			throw new Nette\InvalidArgumentException('Password can not be empty.');
+		}
+
 		$hash = isset($this)
 			? @password_hash($password, $this->algo, $this->options) // @ is escalated to exception
 			: @password_hash($password, PASSWORD_BCRYPT, func_get_args()[1] ?? []); // back compatibility with v2.x

--- a/tests/Security/Passwords.hash().phpt
+++ b/tests/Security/Passwords.hash().phpt
@@ -14,7 +14,7 @@ require __DIR__ . '/../bootstrap.php';
 
 
 Assert::truthy(
-	preg_match('#^\$.{50,}\z#', (new Passwords)->hash(''))
+	preg_match('#^\$.{50,}\z#', (new Passwords)->hash('my-password'))
 );
 
 Assert::truthy(
@@ -27,3 +27,7 @@ Assert::same($hash, crypt('dg', $hash));
 Assert::exception(function () {
 	(new Passwords(PASSWORD_BCRYPT, ['cost' => 3]))->hash('dg');
 }, Nette\InvalidStateException::class, 'Computed hash is invalid. password_hash(): Invalid bcrypt cost parameter specified: 3');
+
+Assert::exception(function () {
+	(new Passwords)->hash('');
+}, Nette\InvalidArgumentException::class, 'Password can not be empty.');

--- a/tests/Security/Passwords.static.phpt
+++ b/tests/Security/Passwords.static.phpt
@@ -15,7 +15,7 @@ require __DIR__ . '/../bootstrap.php';
 
 // deprecated static usage
 Assert::error(function () {
-	Passwords::hash('');
+	Passwords::hash('my-password');
 }, E_DEPRECATED, 'Non-static method Nette\Security\Passwords::hash() should not be called statically');
 
 Assert::truthy(


### PR DESCRIPTION
- new feature
- BC break? yes

I think the password can not be never empty (safe check).
