### PR TITLE
Added method User::refresh() to clear identity cache. (#46)

### DIFF
--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -309,6 +309,7 @@ class User
 	final public function refresh()
 	{
 		$this->identity = false;
+		$this->authenticated = null;
 		return $this;
 	}
 

--- a/src/Security/User.php
+++ b/src/Security/User.php
@@ -302,6 +302,17 @@ class User
 	}
 
 
+	/**
+	 * Clear identity cache.
+	 * @return $this
+	 */
+	final public function refresh()
+	{
+		$this->identity = false;
+		return $this;
+	}
+
+
 	/** @deprecated */
 	final public function hasAuthorizator(): bool
 	{


### PR DESCRIPTION
- new feature  #46
- BC break? no

Example in BasePresenter.php:
```
public function startup()
{
	$this->getUser()->getStorage()->setNamespace('namespace_1');
	.
	.
	.
	$this->getUser()->refresh()->getStorage()->setNamespace('namespace_2');
}
```
