### PR TITLE
UserPanel: Headers can be sent with closed session

### DIFF
--- a/src/Bridges/SecurityTracy/UserPanel.php
+++ b/src/Bridges/SecurityTracy/UserPanel.php
@@ -35,7 +35,7 @@ class UserPanel implements Tracy\IBarPanel
 	 */
 	public function getTab(): ?string
 	{
-		if (headers_sent() && !session_id()) {
+		if (headers_sent() || !session_id()) {
 			return null;
 		}
 


### PR DESCRIPTION
- bug fix
- BC break? yes

When headers has been sent and session has been closed panel throw exception like this:

![Snímek obrazovky 2020-11-11 v 22 02 39](https://user-images.githubusercontent.com/4738758/98864080-9e3e9680-2469-11eb-956b-bf92d772bcb4.png)
