### PR TITLE
SessionStorage: Fix clearing identity in case of clearAuthentication(true).

### DIFF
--- a/src/Bridges/SecurityHttp/SessionStorage.php
+++ b/src/Bridges/SecurityHttp/SessionStorage.php
@@ -57,6 +57,9 @@ final class SessionStorage implements Nette\Security\UserStorage
 		$section->authenticated = false;
 		$section->reason = self::LOGOUT_MANUAL;
 		$section->authTime = null;
+		if ($clearIdentity === true) {
+			$section->identity = null;
+		}
 
 		// Session Fixation defence
 		$this->sessionHandler->regenerateId();


### PR DESCRIPTION
- bug fix
- BC break? yes

User defined code (for logout function):

```php
$this->userStorage->clearAuthentication(true);
$this->userStorage->setExpiration(null, true);
```

Mark user as unauthenticated, but an original identity kept stored in Session. I think when `clearAuthentication(true)` the identity must be removed.